### PR TITLE
Disable mesa_glthread to fix issues with Plains of Eidolon. Fixes #4

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -38,7 +38,6 @@ echo "#!/bin/bash" > warframe.sh
 
 echo "export PULSE_LATENCY_MSEC=60" >> warframe.sh
 echo "export __GL_THREADED_OPTIMIZATIONS=1" >> warframe.sh
-echo "export mesa_glthread=true" >> warframe.sh
 echo "cd /home/$USER/Warframe/drive_c/Program\ Files/Warframe/" >> warframe.sh
 echo "WINEPREFIX=/home/$USER/Warframe WINEDEBUG=-all wine cmd /C Warframe-Launcher.bat" >> warframe.sh
 

--- a/wf.reg
+++ b/wf.reg
@@ -28,6 +28,9 @@ REGEDIT4
 "DownloadDir"="C:\\Program Files\\Warframe\\Downloaded"
 "LauncherExe"="C:\\users\\%USERNAME%\\Local Settings\\Application Data\\Warframe\\Downloaded\\Public\\Tools\\Launcher.exe"
 
+[HKEY_CURRENT_USER\Software\Wine\DllRedirects]
+ "wined3d"="wined3d-csmt.dll"
+
 [HKEY_CURRENT_USER\Software\Wine\Direct3D]
 "OffscreenRenderingMode"="fbo"
 "RenderTargetLockMode"="readtex"


### PR DESCRIPTION
I disabled the mesa_glthread option and reverted to CSMT.
This fixed the issues mentioned in #4 for me.
I had some time to do some testing and I have not seen any issues so far.