### PR TITLE
download latest index.txt from origin.warframe.com

### DIFF
--- a/updater.sh
+++ b/updater.sh
@@ -4,7 +4,7 @@ EXEPREFIX="$WINEPREFIX/drive_c/Program Files/Warframe/Downloaded/Public"
 
 WINECMD=${WINE-wine}
 
-wget -qN http://content.warframe.com/index.txt.lzma
+wget -qN http://origin.warframe.com/index.txt.lzma
 unlzma -f index.txt.lzma
 
 echo "*********************"


### PR DESCRIPTION
download latest index.txt from origin.warframe.com instead of content.origin.com. The later seems to be slightly out of date

should fix #25