### PR TITLE
Stream compressed data directly to the decompressor

### DIFF
--- a/updater.sh
+++ b/updater.sh
@@ -199,10 +199,8 @@ if [ "$do_update" = true ] ; then
 			#download file and replace old file
 			#keep wget as a backup in case curl fails
 			#wget -x -O "$EXEPREFIX$line" http://content.warframe.com$line
-			curl $DOWNLOAD_URL --create-dirs -o "$LZMA_PATH"
-			echo "Extracting file. This can take some time for large files."
-			unlzma -f "$LZMA_PATH"
-			mv "$EXTRACTED_PATH" "$LOCAL_PATH"
+			mkdir -p "$(dirname "$LOCAL_PATH")"
+			curl $DOWNLOAD_URL | unlzma - > "$LOCAL_PATH"
 		fi
 
 		#update local index


### PR DESCRIPTION
Removes a round-trip the data has to make to disk, and the network and CPU bottlenecks are now in parallel, rather than in series, so overall update speed should improve.