### PR TITLE
Fix hard dependency on xterm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/warframe.png

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-##  Not supported on Solus because for some stupid reason Solus doesn't have xterm when literally every other distro does.
-
 ## If you're getting crashes  
 Report them on winehq. Nothing on my launcher can fix what wine breaks. All this does is set up a prefix and update/download/launch the game.  If you find a missing override or library, report it, but do not report crashes here without an answer.  
 
@@ -41,7 +39,7 @@ directory. Run `./install.sh --help` to see all available options.
   type "warframe" in a terminal
 ```
 
-5. The launcher will open and run in an xterm terminal. It will then launch two "black boxes", one after another. This is Warframe.exe double checking for missed updates, and then optimizing the game cache. Once these launch they will close by themselves, and the game will launch, then the xterm window will close.  
+5. The launcher will open and run in a terminal. It will then launch two "black boxes", one after another. This is Warframe.exe double checking for missed updates, and then optimizing the game cache. Once these launch they will close by themselves, and the game will launch, then the termnal window will close.
 
 ## Uninstallation/Removal Instructions
 This applies to non-lutris only: 

--- a/install.sh
+++ b/install.sh
@@ -128,7 +128,7 @@ function mkdesktop() {
 Encoding=UTF-8
 Name=Warframe
 GenericName=Warframe
-Exec="$WFDIR/warframe.sh" "\$@"
+Exec="$WFDIR/warframe.sh"
 Icon="$WFDIR/warframe.png"
 StartupNotify=true
 Terminal=false

--- a/install.sh
+++ b/install.sh
@@ -102,15 +102,7 @@ export WINEDEBUG=$WINEDEBUG
 export WINEPREFIX="$WINEPREFIX"
 
 cd "$WFDIR"
-if [ ! -z "$@" ]; then
-    if [ "$@" = "-h" ] || [ "$@" = "--help" ]; then
-        xterm -bg black -fg white -hold -e "./updater.sh $@"
-    fi
-else
-    xterm -bg black -fg white -e "./updater.sh $@"
-fi
-
-
+exec ./updater.sh "\$@"
 EOF
 
 chmod a+x warframe.sh

--- a/install.sh
+++ b/install.sh
@@ -64,7 +64,9 @@ pushd "$WFDIR"
 cat > uninstall.sh <<EOF
 #!/bin/bash
 
-sudo rm -R /usr/bin/warframe
+if [ -e /usr/bin/warframe ]; then
+	sudo rm -R /usr/bin/warframe
+fi
 rm -R "\$HOME/Desktop/warframe.desktop" "$GAMEDIR" \\
       "\$HOME/.local/share/applications/warframe.desktop"
 echo "Warframe has been successfully removed."

--- a/updater.exe
+++ b/updater.exe
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cd $WINEPREFIX/drive_c/Program\ Files/Warframe/
-xterm -bg black -fg white -e "./updater.sh $@"
+./updater.sh "$@"

--- a/updater.sh
+++ b/updater.sh
@@ -2,6 +2,19 @@
 # exit on first error
 set -e
 
+# If we are not already running in a terminal
+if [ ! -t 1 ]; then
+	# Find a suitable one
+	for i in x-terminal-emulator xterm gnome-terminal; do
+		if which $i &>/dev/null; then
+			# And respawn ourself inside it
+			exec $i -e "$0" "$@"
+		fi
+	done
+
+	# Couldn't find a terminal to run in. Just continue.
+fi
+
 # create folders if they don't exist
 if [ ! -d "$WINEPREFIX/drive_c/Program Files/Warframe/Downloaded" ]; then
   mkdir -p "$WINEPREFIX/drive_c/Program Files/Warframe/Downloaded/Public"


### PR DESCRIPTION
~~`Terminal=true` in the `.desktop` file will tell the desktop environment to find a terminal emulator to run the app in. Properly fixes #48. Also, drop the xterm call from the Lutris path, since Lutris already has an option to run in a terminal (perhaps it's possible to enable it by default?).~~

Redid patchset. New solution is to have updater.sh respawn itself in a terminal if it detects that it is not already in one. The hard dependency on xterm is removed by checking for an available terminal emulator among a set that basically everyone should have one of.

Two other misc patches included.